### PR TITLE
Remove obsolete AuthUtil logger

### DIFF
--- a/Common/src/main/resources/logback-spring.xml
+++ b/Common/src/main/resources/logback-spring.xml
@@ -25,12 +25,6 @@
         <appender-ref ref="FILE"/>
     </logger>
 
-    <!-- JWT Logging -->
-    <logger name="com.projectx.common.utils.AuthUtil" level="DEBUG" additivity="false">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
-    </logger>
-
     <!-- User Service Logging -->
     <logger name="com.projectx.common.service.UserService" level="INFO" additivity="false">
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
## Summary
- delete AuthUtil logger entry from logback configuration

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687b52a141a4832c898617433965bf5d