### PR TITLE
Externalize Keycloak secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Project X
+
+This project uses Keycloak for authentication. The Keycloak client secret should never be committed to source control.
+
+All modules expect the secret via the `KEYCLOAK_SECRET` environment variable. You can export it locally or provide it through your secrets manager.
+
+Example run:
+```bash
+export KEYCLOAK_SECRET=your-secret
+./mvnw spring-boot:run -pl Root
+```
+
+When using Docker Compose or another orchestrator, configure this variable using an `.env` file or the platform's secret facilities.
+

--- a/Root/src/main/resources/application.properties
+++ b/Root/src/main/resources/application.properties
@@ -40,8 +40,8 @@ keycloak.resource=projectx-app
 keycloak.public-client=false
 keycloak.confidential-port=0
 
-# Client Secret (Keycloak'tan aldığınız secret'ı buraya yazın)
-keycloak.credentials.secret=3XdbrKegs4ylju76c50p07Vb16G5DYd9
+# Client Secret (should be provided via environment variable or secrets manager)
+keycloak.credentials.secret=${KEYCLOAK_SECRET}
 
 # Spring Security OAuth2 Configuration
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:9090/realms/projectx
@@ -49,7 +49,7 @@ spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:9090/real
 
 # OAuth2 Client Configuration
 spring.security.oauth2.client.registration.keycloak.client-id=projectx-app
-spring.security.oauth2.client.registration.keycloak.client-secret=3XdbrKegs4ylju76c50p07Vb16G5DYd9
+spring.security.oauth2.client.registration.keycloak.client-secret=${KEYCLOAK_SECRET}
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.keycloak.scope=openid,profile,email
 spring.security.oauth2.client.registration.keycloak.redirect-uri=http://localhost:8080/login/oauth2/code/keycloak


### PR DESCRIPTION
## Summary
- replace Keycloak secret in Root application.properties with `${KEYCLOAK_SECRET}`
- add README documenting the `KEYCLOAK_SECRET` environment variable

## Testing
- `./mvnw -q test` *(fails: unable to download Maven due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_687b529de97c832c9cb2514572e8dcad