### PR TITLE
Remove redundant hbm2ddl property

### DIFF
--- a/Root/src/main/resources/application.properties
+++ b/Root/src/main/resources/application.properties
@@ -12,18 +12,17 @@ spring.h2.console.path=/h2-console
 
 # JPA/Hibernate Configuration
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=create
+# use create-drop to rebuild the schema on each start
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# Force Hibernate to refresh metadata
-spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop
+# Schema generation settings
 spring.jpa.properties.hibernate.hbm2ddl.schema_generation.drop_source=metadata
 spring.jpa.properties.hibernate.hbm2ddl.schema_generation.create_source=metadata
 
 # H2 specific properties
 spring.jpa.properties.hibernate.hbm2ddl.halt_on_error=false
-spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop
 
 # Logging
 logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
## Summary
- switch to `create-drop` for consistent schema generation
- remove duplicate `hbm2ddl.auto` settings
- comment the chosen strategy in `application.properties`

## Testing
- `mvnw -q test` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b529f2a48832ca33fc7d560dc0b24